### PR TITLE
File Search Node added for MacOS

### DIFF
--- a/desktop/macos/fileSearch.html
+++ b/desktop/macos/fileSearch.html
@@ -41,7 +41,15 @@
 
     <div class="form-row">
       <label for="node-input-kind"><i class="fa fa-tag"></i> Kind</label>
-      <input type="text" id="node-input-kind" style="width:70%;" />
+      <select name="kind" id="node-input-kind" style="width:70%;" />
+        <option value="app">app</option>
+        <option value="image">image</option>
+        <option value="pdf">pdf</option>
+        <option value="presentation">ppt</option>
+        <option value="audio">audio/music</option>
+        <option value="movie">movie/video</option>
+        <option value="folder">folder</option>
+      </select>
     </div>
 
     <div class="form-row">

--- a/desktop/macos/fileSearch.html
+++ b/desktop/macos/fileSearch.html
@@ -1,0 +1,56 @@
+<script type="text/javascript">
+  RED.nodes.registerType("desktop-macos-file-search", {
+    category: "macos",
+    color: "#8BBDD9",
+    defaults: {
+      name: { value: "" },
+      fileName: {
+        value: "", 
+        required: false
+      },
+      kind: {
+        value: "", 
+        required: false
+      },
+      onlyin: {
+        value: "", 
+        required: false
+      }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: "fa-keyboard-o.png",
+    label: function () {
+      return this.name || "File Search";
+    },
+    paletteLabel: "macos-file-search",
+   });
+</script>
+
+<script type="text/x-red" data-template-name="desktop-macos-file-search">
+
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" style="width:70%;" placeholder="Name" />
+    </div>
+
+    <div class="form-row">
+      <label for="node-input-fileName"><i class="fa fa-tag"></i> File Name</label>
+      <input type="text" id="node-input-fileName" style="width:70%;" />
+    </div>
+
+    <div class="form-row">
+      <label for="node-input-kind"><i class="fa fa-tag"></i> Kind</label>
+      <input type="text" id="node-input-kind" style="width:70%;" />
+    </div>
+
+    <div class="form-row">
+      <label for="node-input-onlyin"><i class="fa fa-tag"></i> onlyin</label>
+      <input type="text" id="node-input-onlyin" style="width:70%;"/>
+    </div>
+
+</script>
+
+<script type="text/x-red" data-help-name="desktop-macos-file-search">
+  <p>Search for files on MacOS</p>
+</script>

--- a/desktop/macos/fileSearch.html
+++ b/desktop/macos/fileSearch.html
@@ -41,7 +41,7 @@
 
     <div class="form-row">
       <label for="node-input-kind"><i class="fa fa-tag"></i> Kind</label>
-      <select name="kind" id="node-input-kind" style="width:70%;" />
+      <select name="kind" id="node-input-kind" style="width:70%;" >
         <option value="app">app</option>
         <option value="image">image</option>
         <option value="pdf">pdf</option>
@@ -53,12 +53,19 @@
     </div>
 
     <div class="form-row">
-      <label for="node-input-onlyin"><i class="fa fa-tag"></i> Search in directory</label>
+      <label for="node-input-onlyin"><i class="fa fa-tag"></i> Directory</label>
       <input type="text" id="node-input-onlyin" style="width:70%;"/>
     </div>
 
 </script>
 
 <script type="text/x-red" data-help-name="desktop-macos-file-search">
-  <p>Search for files on MacOS</p>
+  <p>Search for files on MacOS. It takes the following inputs:<br><br>
+
+    fileName: name of the file/search term<br>
+    kind: The file type (default is 'app')<br>
+    Directory: Directory inside which you want to search for the file<br><br>
+
+    If the node is pre-configured by the user, it takes that value, otherwise it fetches values from msg.payload
+  </p>
 </script>

--- a/desktop/macos/fileSearch.html
+++ b/desktop/macos/fileSearch.html
@@ -4,18 +4,22 @@
     color: "#8BBDD9",
     defaults: {
       name: { value: "" },
-      fileName: {
+      query: {
         value: "", 
-        required: false
+        required: true,
+        validate: RED.validators.typedInput("queryType"),
       },
+      queryType: { value: "str" },
       kind: {
         value: "", 
         required: false
       },
       onlyin: {
         value: "", 
-        required: false
-      }
+        required: false,
+        validate: RED.validators.typedInput("onlyinType"),
+      },
+      onlyinType: { value: "str" },
     },
     inputs: 1,
     outputs: 1,
@@ -24,6 +28,47 @@
       return this.name || "File Search";
     },
     paletteLabel: "macos-file-search",
+    oneditprepare: function () {
+      // query node
+      if (this.queryType == null) {
+        if (this.query == "") {
+          this.queryType = "date";
+        } else {
+          this.queryType = "str";
+        }
+      } else if (this.queryType === "string" || this.queryType === "none") {
+        this.queryType = "str";
+      }
+      $("#node-input-queryType").val(this.queryType);
+
+      $("#node-input-query").typedInput({
+        default: "str",
+        typeField: $("#node-input-queryType"),
+        types: ["flow", "global", "msg", "str"],
+      });
+
+      $("#node-input-query").typedInput("type", this.queryType);
+
+      //onlyin node
+      if (this.onlyinType == null) {
+        if (this.onlyin == "") {
+          this.onlyinType = "date";
+        } else {
+          this.onlyinType = "str";
+        }
+      } else if (this.onlyinType === "string" || this.onlyinType === "none") {
+        this.onlyinType = "str";
+      }
+      $("#node-input-onlyinType").val(this.onlyinType);
+
+      $("#node-input-onlyin").typedInput({
+        default: "str",
+        typeField: $("#node-input-onlyinType"),
+        types: ["flow", "global", "msg", "str"],
+      });
+
+      $("#node-input-onlyin").typedInput("type", this.onlyinType);
+    },
    });
 </script>
 
@@ -35,8 +80,9 @@
     </div>
 
     <div class="form-row">
-      <label for="node-input-fileName"><i class="fa fa-tag"></i> File Name</label>
-      <input type="text" id="node-input-fileName" style="width:70%;" />
+      <label for="node-input-query"><i class="fa fa-tag"></i> Search query</label>
+      <input type="text" id="node-input-query" style="width:70%;" />
+      <input type="hidden" id="node-input-queryType">
     </div>
 
     <div class="form-row">
@@ -49,12 +95,14 @@
         <option value="audio">audio/music</option>
         <option value="movie">movie/video</option>
         <option value="folder">folder</option>
+        <option value="msg.payload.kind">msg.payload.kind</option>
       </select>
     </div>
 
     <div class="form-row">
       <label for="node-input-onlyin"><i class="fa fa-tag"></i> Directory</label>
       <input type="text" id="node-input-onlyin" style="width:70%;"/>
+      <input type="hidden" id="node-input-onlyinType">
     </div>
 
 </script>
@@ -62,8 +110,8 @@
 <script type="text/x-red" data-help-name="desktop-macos-file-search">
   <p>Search for files on MacOS. It takes the following inputs:<br><br>
 
-    fileName: name of the file/search term<br>
-    kind: The file type (default is 'app')<br>
+    query: name of the file/search term<br>
+    kind: The file type (default is 'app'). If msg.payload.kind is selected, it selects the value from msg.payload.kind<br>
     Directory: Directory inside which you want to search for the file<br><br>
 
     If the node is pre-configured by the user, it takes that value, otherwise it fetches values from msg.payload

--- a/desktop/macos/fileSearch.html
+++ b/desktop/macos/fileSearch.html
@@ -53,7 +53,7 @@
     </div>
 
     <div class="form-row">
-      <label for="node-input-onlyin"><i class="fa fa-tag"></i> onlyin</label>
+      <label for="node-input-onlyin"><i class="fa fa-tag"></i> Search in directory</label>
       <input type="text" id="node-input-onlyin" style="width:70%;"/>
     </div>
 

--- a/desktop/macos/fileSearch.js
+++ b/desktop/macos/fileSearch.js
@@ -1,0 +1,76 @@
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+module.exports = function (RED) {
+  function DesktopMacOSFileSeach(config) {
+    RED.nodes.createNode(this, config);
+    this.fileName = config.fileName;
+    this.kind = config.kind;
+    this.onlyin = config.onlyin;
+    var node = this;
+
+    const getIcon = async (filePath) => {
+      const {stdout, stderr, err} = await exec(`ls ${filePath.replace(/\s/g, '\\ ')+"/Contents/Resources/*.icns"}`);
+      if(stderr || err){
+          return "";
+      }
+      return stdout.split('\n')[0]
+    }
+
+    const findFiles = async (fileName, kind, onlyin) => {
+      let out = [];
+      let allowedKinds = ["app", "application", "applications", "audio", "music", "folder", "folders", "image", "images", "movie", "movies", "pdf", "pdfs", "presentation", "presentations", "email", "emails"];
+      if(!(fileName && fileName!== "")){
+        return {out, err: "invalid configs"};
+      }
+      console.log("configs", fileName, kind, onlyin)
+      try{
+          let command = `cd ~ && mdfind kind:${kind && allowedKinds.includes(kind) ? kind : "app"} ${onlyin ? "-onlyin "+onlyin+" " : ""}${fileName}`;
+          const {stdout,stderr} = await exec(command);
+          if(stderr){
+              throw Error(stderr);
+          }
+          //console.log(stdout);
+          let filePaths = stdout.slice(0,-1).split('\n');
+          
+          for(let filePath of filePaths){
+              var displayName = filePath.substring(filePath.lastIndexOf("/")+1, filePath.length-4);
+              let obj = {
+                  "value" : displayName, 
+                      "meta": {
+                          "path": filePath,
+                          "kind": kind
+                      }
+              };
+              if(kind === "app"){
+                  obj.meta.icon = await getIcon(filePath).catch((e) => {
+                      //console.log("here",e);
+                  });
+              }
+              out.push(obj);
+          }
+      }
+      catch(e){
+          return {out, err: e};
+          console.log(e);
+      }
+      return {out, err: null};
+    };
+
+    //modifying code here
+    this.on("input", async (msg) => {
+      // fetch details from msg.payload as well
+      const {fileName,kind,onlyin} = msg.payload;
+      this.fileName = this.fileName ? this.fileName : fileName;
+      this.kind = this.kind ? this.kind : kind;
+      this.onlyin = this.onlyin ? this.onlyin : onlyin;
+      const {out,err} = await findFiles(this.fileName,this.kind, this.onlyin);
+      if(err){
+        node.error(err)
+      }
+      msg.payload = out;
+      node.send(msg);
+    });
+  }
+  RED.nodes.registerType("desktop-macos-file-search", DesktopMacOSFileSeach);
+};

--- a/desktop/macos/fileSearch.js
+++ b/desktop/macos/fileSearch.js
@@ -4,9 +4,11 @@ const exec = util.promisify(require('child_process').exec);
 module.exports = function (RED) {
   function DesktopMacOSFileSeach(config) {
     RED.nodes.createNode(this, config);
-    this.fileName = config.fileName;
+    this.query = config.query;
+    this.queryType = config.queryType;
     this.kind = config.kind;
     this.onlyin = config.onlyin;
+    this.onlyinType = config.onlyinType;
     var node = this;
 
     const getIcon = async (filePath) => {
@@ -17,15 +19,15 @@ module.exports = function (RED) {
       return stdout.split('\n')[0]
     }
 
-    const findFiles = async (fileName, kind, onlyin) => {
+    const findFiles = async (query, kind, onlyin) => {
       let out = [];
       let allowedKinds = ["app", "application", "applications", "audio", "music", "folder", "folders", "image", "images", "movie", "movies", "pdf", "pdfs", "presentation", "presentations", "email", "emails"];
-      if(!(fileName && fileName!== "")){
+      if(!(query && query!== "")){
         return {out, err: "invalid configs"};
       }
-      console.log("configs", fileName, kind, onlyin)
+      console.log("configs", query, kind, onlyin)
       try{
-          let command = `cd ~ && mdfind kind:${kind && allowedKinds.includes(kind) ? kind : "app"} ${onlyin ? "-onlyin "+onlyin+" " : ""}${fileName}`;
+          let command = `cd ~ && mdfind kind:${kind && allowedKinds.includes(kind) ? kind : "app"} ${onlyin ? "-onlyin "+onlyin+" " : ""}${query}`;
           const {stdout,stderr} = await exec(command);
           if(stderr){
               throw Error(stderr);
@@ -34,7 +36,7 @@ module.exports = function (RED) {
           let filePaths = stdout.slice(0,-1).split('\n');
           
           for(let filePath of filePaths){
-              var displayName = filePath.substring(filePath.lastIndexOf("/")+1, filePath.length-4);
+              var displayName = filePath.substring(filePath.lastIndexOf("/")+1, filePath.length);
               let obj = {
                   "value" : displayName, 
                       "meta": {
@@ -57,20 +59,53 @@ module.exports = function (RED) {
       return {out, err: null};
     };
 
+    async function getValue(value, valueType, msg) {
+      return new Promise(function (resolve, reject) {
+        if (valueType === "str") {
+          resolve(value);
+        } else {
+          RED.util.evaluateNodeProperty(
+            value,
+            valueType,
+            this,
+            msg,
+            function (err, res) {
+              if (err) {
+                node.error(err.msg);
+                reject(err.msg);
+              } else {
+                resolve(res);
+              }
+            }
+          );
+        }
+      });
+    }
+
     //modifying code here
     this.on("input", async (msg) => {
       // fetch details from msg.payload as well
-      const {fileName,kind,onlyin} = msg.payload;
-      this.fileName = this.fileName ? this.fileName : fileName;
-      this.kind = this.kind ? this.kind : kind;
-      this.onlyin = this.onlyin ? this.onlyin : onlyin;
-      const {out,err} = await findFiles(this.fileName,this.kind, this.onlyin);
+      // const {query,kind,onlyin} = msg.payload;
+      // this.query = this.query ? this.query : query;
+      // this.kind = this.kind ? this.kind : kind;
+      // this.onlyin = this.onlyin ? this.onlyin : onlyin;
+
+      let query = await getValue(this.query, this.queryType, msg);
+      let onlyin = await getValue(this.onlyin, this.onlyinType, msg);
+      let kind = this.kind === "msg.payload.kind" ? msg.payload.kind : this.kind;
+      const {out,err} = await findFiles(query, kind, onlyin);
       if(err){
         node.error(err)
       }
       msg.payload = out;
       node.send(msg);
     });
+    oneditprepare: function oneditprepare() {
+      $("#node-input-query").val(this.query);
+      $("#node-input-queryType").val(this.queryType);
+      $("#node-input-onlyin").val(this.onlyin);
+      $("#node-input-onlyinType").val(this.onlyinType);
+    }
   }
   RED.nodes.registerType("desktop-macos-file-search", DesktopMacOSFileSeach);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maya-red-system-utils",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       "desktop-clipboard-get": "desktop/clipboard/get.js",
       "desktop-system-open": "desktop/system/open.js",
       "desktop-system-notify": "desktop/system/notify.js",
-      "desktop-macos-notify": "desktop/macos/notify.js"
+      "desktop-macos-notify": "desktop/macos/notify.js",
+      "desktop-macos-file-search": "desktop/macos/fileSearch.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
File search node added which takes the following inputs:

- fileName: name of the file/search term
- kind: The kind of app, needs to be selected from the drop-down. (default is app)
- onlyin: Directory inside which you want to search for the file

If the node is pre-configured by the user, it takes that value, otherwise it fetches values from msg.payload.